### PR TITLE
Add remove from defaults for optional and support of NSCoding

### DIFF
--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/SwiftDefaults.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/SwiftDefaults.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'AADE0F29D96DB30DA6DC5314'
+               BlueprintIdentifier = 'AC9FF491F52326170F66ED1A'
                BlueprintName = 'SwiftDefaults'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'SwiftDefaults.framework'>

--- a/Example/SwiftDefaults.xcodeproj/project.pbxproj
+++ b/Example/SwiftDefaults.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
+		9C8FE3D31C5298A700E3DDB1 /* Person.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8FE3D21C5298A700E3DDB1 /* Person.swift */; };
 		E4CB2AF31C4529F400DC772B /* MyDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CB2AF21C4529F400DC772B /* MyDefaults.swift */; };
 /* End PBXBuildFile section */
 
@@ -41,6 +42,7 @@
 		607FACE51AFB9204008FA782 /* SwiftDefaults_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftDefaults_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		9C8FE3D21C5298A700E3DDB1 /* Person.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
 		ADE7D53BA78AAC528976FEA1 /* Pods-SwiftDefaults_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftDefaults_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftDefaults_Tests/Pods-SwiftDefaults_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		BAE096ED514000AC5278E1AF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		BD34377769DB16E0C01989B6 /* Pods-SwiftDefaults_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftDefaults_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftDefaults_Example/Pods-SwiftDefaults_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -107,6 +109,7 @@
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				607FACD71AFB9204008FA782 /* ViewController.swift */,
 				E4CB2AF21C4529F400DC772B /* MyDefaults.swift */,
+				9C8FE3D21C5298A700E3DDB1 /* Person.swift */,
 				607FACD91AFB9204008FA782 /* Main.storyboard */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
@@ -364,6 +367,7 @@
 			files = (
 				E4CB2AF31C4529F400DC772B /* MyDefaults.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
+				9C8FE3D31C5298A700E3DDB1 /* Person.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/SwiftDefaults/MyDefaults.swift
+++ b/Example/SwiftDefaults/MyDefaults.swift
@@ -13,4 +13,6 @@ class MyDefaults: SwiftDefaults {
     dynamic var value: String? = "10"
     dynamic var value2: String = "10"
     dynamic var value3: Int = 1
+    dynamic var value4: Person? = nil
 }
+

--- a/Example/SwiftDefaults/Person.swift
+++ b/Example/SwiftDefaults/Person.swift
@@ -1,0 +1,38 @@
+//
+//  Person.swift
+//  SwiftDefaults
+//
+//  Created by VLADIMIR KONEV on 22.01.16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import Foundation
+
+class Person: NSObject, NSCoding{
+    var firstName: String? = ""
+    var lastName: String? = ""
+    var age: Int = 18
+
+    override init(){
+        super.init()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        firstName = aDecoder.decodeObjectForKey("firstName") as? String
+        lastName = aDecoder.decodeObjectForKey("lastName") as? String
+        age = aDecoder.decodeIntegerForKey("age")
+    }
+    
+    func encodeWithCoder(aCoder: NSCoder) {
+        aCoder.encodeObject(firstName, forKey: "firstName")
+        aCoder.encodeObject(lastName, forKey: "lastName")
+        aCoder.encodeInteger(age, forKey: "age")
+    }
+}
+
+extension Person{
+    // Readable print
+    override var description: String{
+        return "Person=\(firstName, lastName, age)"
+    }
+}

--- a/Example/SwiftDefaults/ViewController.swift
+++ b/Example/SwiftDefaults/ViewController.swift
@@ -16,5 +16,17 @@ class ViewController: UIViewController {
         print(MyDefaults().value2)
         MyDefaults().value2 = "2"
         print(MyDefaults().value2)
+        
+        
+        print("Stored person instance: \(MyDefaults().value4)")
+        let p = Person()
+        p.firstName = "Elvis"
+        p.lastName = "Presley"
+        p.age = 42
+        MyDefaults().value4 = p
+        print("Stored person instance: \(MyDefaults().value4)")
+        MyDefaults().value4 = nil
+        print("Stored nil person: \(MyDefaults().value4)")
+        
     }
 }

--- a/Pod/Classes/SwiftDefaults.swift
+++ b/Pod/Classes/SwiftDefaults.swift
@@ -19,7 +19,12 @@ public class SwiftDefaults: NSObject {
 extension SwiftDefaults {
     override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         if let keyPath = keyPath {
-            userDefaults.setObject(change?["new"], forKey: keyPath)
+            if let value = change?["new"] where !(value is NSNull) {
+                userDefaults.setObject(value is NSCoding ? NSKeyedArchiver.archivedDataWithRootObject(value) : value, forKey: keyPath)
+            }else{
+                userDefaults.removeObjectForKey(keyPath)
+            }
+
             userDefaults.synchronize()
         }
     }
@@ -36,7 +41,12 @@ extension SwiftDefaults {
     
     private func setupProperty() {
         propertyNames.forEach {
-            setValue(userDefaults.objectForKey($0), forKey: $0)
+            let value = userDefaults.objectForKey($0)
+            if let data = value as? NSData, decodedValue = NSKeyedUnarchiver.unarchiveObjectWithData(data){
+                setValue(decodedValue, forKey: $0)
+            }else{
+                setValue(value, forKey: $0)
+            }
         }
     }
     

--- a/Pod/Classes/SwiftDefaults.swift
+++ b/Pod/Classes/SwiftDefaults.swift
@@ -20,7 +20,7 @@ extension SwiftDefaults {
     override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         if let keyPath = keyPath {
             if let value = change?["new"] where !(value is NSNull) {
-                userDefaults.setObject(value is NSCoding ? NSKeyedArchiver.archivedDataWithRootObject(value) : value, forKey: keyPath)
+                userDefaults.setObject(value is NSCoding ? NSKeyedArchiver.archivedDataWithRootObject(value) : value, forKey: storeKey(keyPath))
             }else{
                 userDefaults.removeObjectForKey(keyPath)
             }
@@ -31,9 +31,13 @@ extension SwiftDefaults {
 }
 
 extension SwiftDefaults {
+    private func storeKey(propertyName: String) -> String{
+        return "\(self.dynamicType)_\(propertyName)"
+    }
+    
     private func registerDefaults() {
         let dic = propertyNames.reduce([String:AnyObject]()) { (var dic, key) -> [String:AnyObject] in
-            dic[key] = valueForKey(key)
+            dic[storeKey(key)] = valueForKey(key)
             return dic
         }
         userDefaults.registerDefaults(dic)
@@ -41,7 +45,7 @@ extension SwiftDefaults {
     
     private func setupProperty() {
         propertyNames.forEach {
-            let value = userDefaults.objectForKey($0)
+            let value = userDefaults.objectForKey(storeKey($0))
             if let data = value as? NSData, decodedValue = NSKeyedUnarchiver.unarchiveObjectWithData(data){
                 setValue(decodedValue, forKey: $0)
             }else{
@@ -66,3 +70,5 @@ extension SwiftDefaults {
         return Mirror(reflecting: self).children.flatMap { $0.label }
     }
 }
+
+

--- a/Pod/Classes/SwiftDefaults.swift
+++ b/Pod/Classes/SwiftDefaults.swift
@@ -22,7 +22,7 @@ extension SwiftDefaults {
             if let value = change?["new"] where !(value is NSNull) {
                 userDefaults.setObject(value is NSCoding ? NSKeyedArchiver.archivedDataWithRootObject(value) : value, forKey: storeKey(keyPath))
             }else{
-                userDefaults.removeObjectForKey(keyPath)
+                userDefaults.removeObjectForKey(storeKey(keyPath))
             }
 
             userDefaults.synchronize()

--- a/README.md
+++ b/README.md
@@ -16,12 +16,22 @@ class MyDefaults: SwiftDefaults {
     dynamic var value: String? = "10"
     dynamic var value2: String = "10"
     dynamic var value3: Int = 1
+    dynamic var value4: Person? = nil
 }
 
-print(MyDefaults().value) // "10"
-print(MyDefaults().value2) // "10"
+print(MyDefaults().value2)
 MyDefaults().value2 = "2"
-print(MyDefaults().value2) // "2"
+print(MyDefaults().value2)
+
+print("Stored person instance: \(MyDefaults().value4)")
+let p = Person()
+p.firstName = "Elvis"
+p.lastName = "Presley"
+p.age = 42
+MyDefaults().value4 = p
+print("Stored person instance: \(MyDefaults().value4)")
+MyDefaults().value4 = nil
+print("Stored nil person: \(MyDefaults().value4)")
 ```
 
 ## Usage


### PR DESCRIPTION
### Fix for optional variables

Fix problem with setting `optional` variables to `nil` value that have led  to exception. Now for optional variables setting to `nil` will emit `removeObjectForKey(_)` of `NSUserDefaults` class.
### Support of non-plist variables

Now support store as variables object that conforms to `NSCoding` protocol.
### Support of same names in different classes

Class name now used to generate string key for store variable in `NSUserDefaults` - it removes possible collisions in case of usage same variable names in different childs of `SwiftDefaults`. 
For example:

``` swift
class MyDefaults: SwiftDefaults{
    dynamic var value1: Bool = true
    // Will save value under key `MyDefaults_value1`
}

class AnotherDefaults: SwiftDefaults{
    dynamic var value1: Bool = true
    // Will save value under key `AnotherDefaults_value1`
}
```
